### PR TITLE
🎨 ViewModelの@Observable化 - Phase 2-1 完了

### DIFF
--- a/BusdesNativeiOS/ViewModels/AddLineViewModel.swift
+++ b/BusdesNativeiOS/ViewModels/AddLineViewModel.swift
@@ -1,34 +1,59 @@
-import Combine
 import Foundation
+import Observation
 
+/// バス停選択画面のViewModel
+/// @Observableパターンで状態管理を簡素化
 @MainActor
-class AddLineViewModel: ObservableObject {
-    @Published var searchQuery: String = ""
-    @Published var filteredData: [BusStop] = []
+@Observable
+final class AddLineViewModel {
+
+    // MARK: - State
+
+    /// 画面の状態を1つの構造体で管理
+    struct State {
+        var searchQuery: String = ""
+        var filteredData: [BusStop] = []
+        var errorMessage: String? = nil
+    }
+
+    var state = State()
+
+    // MARK: - Dependencies
+
     private var busStops: [BusStop] = []
     private let busStopRepository: BusStopRepository
+
+    // MARK: - Initialization
 
     init(busStopRepository: BusStopRepository = BusStopRepository.shared) {
         self.busStopRepository = busStopRepository
         loadBusStops()
-        self.filteredData = busStops
     }
-    
+
+    // MARK: - Public Methods
+
+    /// バス停一覧を読み込む
     private func loadBusStops() {
         do {
             busStops = try busStopRepository.getBusStops()
-            filteredData = busStops
+            state.filteredData = busStops
+            state.errorMessage = nil
         } catch {
             busStops = []
-            filteredData = []
+            state.filteredData = []
+            state.errorMessage = "バス停データの読み込みに失敗しました"
         }
     }
-    
+
+    /// 検索クエリでバス停をフィルタリング
+    /// - Parameter query: 検索文字列
     func filterBusStops(with query: String) {
+        state.searchQuery = query
+
         if query.isEmpty {
-            filteredData = busStops
+            state.filteredData = busStops
         } else {
-            filteredData = busStops.filter {
+            state.filteredData = busStops.filter {
                 $0.name.contains(query) || $0.kana.contains(query)
             }
         }

--- a/BusdesNativeiOS/ViewModels/SetGoalViewModel.swift
+++ b/BusdesNativeiOS/ViewModels/SetGoalViewModel.swift
@@ -1,15 +1,70 @@
-import Combine
 import SwiftUI
+import Observation
 
+/// 目的地設定画面のViewModel
+/// @Observableパターンで状態管理を簡素化
 @MainActor
-class SetGoalViewModel: ObservableObject {
+@Observable
+final class SetGoalViewModel {
+
+    // MARK: - State
+
+    /// 画面の状態を1つの構造体で管理
+    struct State {
+        var selectedGoal: String = "南草津駅"
+        var showAlert: Bool = false
+        var alertMessage: String = ""
+    }
+
+    var state = State()
+
+    // MARK: - Properties
+
     let from: BusStop
+
+    // MARK: - Initialization
 
     init(from: BusStop) {
         self.from = from
     }
 
-    func setRoute(to : String, userModel: UserService) {
+    // MARK: - Public Methods
+
+    /// 目的地を選択
+    /// - Parameter destination: 目的地名（"南草津駅" or "立命館大学"）
+    func selectGoal(_ destination: String) {
+        state.selectedGoal = destination
+    }
+
+    /// 路線を設定
+    /// - Parameters:
+    ///   - to: 目的地
+    ///   - userModel: ユーザーサービス
+    /// - Returns: 設定が成功したかどうか
+    @discardableResult
+    func setRoute(to: String, userModel: UserService) -> Bool {
+        // バリデーション: 乗り場と降り場が同じ
+        if from.name == to {
+            state.alertMessage = "乗り場と降り場が同じようです"
+            state.showAlert = true
+            return false
+        }
+
+        // バリデーション: 既に登録済み
+        if userModel.isRouteSaved(from: from.name, to: to) {
+            state.alertMessage = "既に登録済みのルートです"
+            state.showAlert = true
+            return false
+        }
+
+        // 路線を追加
         userModel.addRoute(from: from.name, to: to)
+        return true
+    }
+
+    /// アラートを閉じる
+    func dismissAlert() {
+        state.showAlert = false
+        state.alertMessage = ""
     }
 }

--- a/BusdesNativeiOS/Views/AddLineView.swift
+++ b/BusdesNativeiOS/Views/AddLineView.swift
@@ -2,12 +2,12 @@ import SwiftUI
 import SwiftData
 
 struct AddLineView: View {
-    @StateObject var viewModel = AddLineViewModel()
+    @State private var viewModel = AddLineViewModel()
     @Binding var path: NavigationPath
 
     var body: some View {
         List {
-            ForEach(viewModel.filteredData, id: \.self) { busStop in
+            ForEach(viewModel.state.filteredData, id: \.self) { busStop in
                 NavigationLink(value: busStop) {
                     VStack(alignment: .leading) {
                         Text(busStop.name)
@@ -18,9 +18,9 @@ struct AddLineView: View {
                 }
             }
         }
-        .searchable(text: $viewModel.searchQuery, placement: .navigationBarDrawer(displayMode: .always), prompt: "バス停名を入力")
-        .onChange(of: viewModel.searchQuery) {
-            viewModel.filterBusStops(with: viewModel.searchQuery)
+        .searchable(text: $viewModel.state.searchQuery, placement: .navigationBarDrawer(displayMode: .always), prompt: "バス停名を入力")
+        .onChange(of: viewModel.state.searchQuery) {
+            viewModel.filterBusStops(with: viewModel.state.searchQuery)
         }
         .navigationDestination(for: BusStop.self) { busStop in
             SetGoalView(from: busStop, path: $path)

--- a/BusdesNativeiOS/Views/SetGoalView.swift
+++ b/BusdesNativeiOS/Views/SetGoalView.swift
@@ -2,18 +2,16 @@ import SwiftUI
 import SwiftData
 
 struct SetGoalView: View {
-    @StateObject private var viewModel: SetGoalViewModel
-    @State private var selectStaition = true
-    @State private var selectedGoal = "南草津駅"
+    @State private var viewModel: SetGoalViewModel
+    @State private var selectStation = true
     @Binding var path: NavigationPath
-    @State private var showAlert = false
     @EnvironmentObject var userModel: UserService
     let receivedBusStop: BusStop
 
     init(from: BusStop, path: Binding<NavigationPath>) {
         self.receivedBusStop = from
         self._path = path
-        _viewModel = StateObject(wrappedValue: SetGoalViewModel(from: from))
+        self.viewModel = SetGoalViewModel(from: from)
     }
 
     var body: some View {
@@ -23,48 +21,49 @@ struct SetGoalView: View {
                 .font(.headline)
             Text("乗り場：\(viewModel.from.name)")
                 .font(.headline)
-                .padding( .top, 50)
+                .padding(.top, 50)
+
             HStack {
                 Spacer()
                 Button {
-                    selectStaition = true
-                    selectedGoal = "南草津駅"
+                    selectStation = true
+                    viewModel.selectGoal("南草津駅")
                 } label: {
                     Text("南草津駅")
                 }
-                .buttonStyle(RoundedRedButton(isSelected: selectStaition))
-                .disabled(selectStaition)
+                .buttonStyle(RoundedRedButton(isSelected: selectStation))
+                .disabled(selectStation)
+
                 Spacer()
                 Button {
-                    selectStaition = false
-                    selectedGoal = "立命館大学"
+                    selectStation = false
+                    viewModel.selectGoal("立命館大学")
                 } label: {
                     Text("立命館大学")
                 }
-                .buttonStyle(RoundedRedButton(isSelected: !selectStaition))
-                .disabled(!selectStaition)
+                .buttonStyle(RoundedRedButton(isSelected: !selectStation))
+                .disabled(!selectStation)
                 Spacer()
             }
             .padding(.top, 50)
+
             Button {
-                if viewModel.from.name == selectedGoal {
-                    showAlert.toggle()
-                    return
-                } else if userModel.isRouteSaved(from: viewModel.from.name, to: selectedGoal) {
-                    showAlert.toggle()
-                    return
+                if viewModel.setRoute(to: viewModel.state.selectedGoal, userModel: userModel) {
+                    // 成功した場合、ナビゲーションをリセット
+                    path.removeLast(path.count)
                 }
-                viewModel.setRoute(to: selectedGoal, userModel: userModel)
-                path.removeLast(path.count)
             } label: {
                 Text("決定")
             }
             .buttonStyle(RoundedGrayButton())
             .padding(.top, 40)
-            .alert(isPresented: $showAlert) {
-                Alert(title: Text("設定エラー"),
-                      message: Text(viewModel.from.name == selectedGoal ? "乗り場と降り場が同じようです" : "既に登録済みのルートです"),
-                      dismissButton: .default(Text("OK"))
+            .alert(isPresented: $viewModel.state.showAlert) {
+                Alert(
+                    title: Text("設定エラー"),
+                    message: Text(viewModel.state.alertMessage),
+                    dismissButton: .default(Text("OK")) {
+                        viewModel.dismissAlert()
+                    }
                 )
             }
             Spacer()


### PR DESCRIPTION
## 📋 概要

Issue #25 (Phase 2-1: 既存ViewModelの@Observable化) の実装です。
AddLineViewModelとSetGoalViewModelを@Observableパターンに統一し、HomeViewModelと同じ状態管理パターンに移行しました。

## 🎯 変更内容

### 1. AddLineViewModel の@Observable化 ✅

**移行内容**:
- `ObservableObject` + `@Published` → `@Observable` + `State` 構造体
- `Combine` framework依存を削除
- エラーメッセージ機能を追加

**変更前**:
```swift
import Combine
import Foundation

@MainActor
class AddLineViewModel: ObservableObject {
    @Published var searchQuery: String = ""
    @Published var filteredData: [BusStop] = []
    private var busStops: [BusStop] = []
}
```

**変更後**:
```swift
import Foundation
import Observation

@MainActor
@Observable
final class AddLineViewModel {
    struct State {
        var searchQuery: String = ""
        var filteredData: [BusStop] = []
        var errorMessage: String? = nil
    }
    var state = State()
    private var busStops: [BusStop] = []
}
```

### 2. SetGoalViewModel の@Observable化 ✅

**移行内容**:
- `ObservableObject` → `@Observable` マクロに移行
- バリデーションロジックをView層からViewModel層に移動
- アラート状態管理をState構造体に統合
- 成功/失敗を`Bool`で返す明示的なAPI設計

**変更前**:
```swift
@MainActor
class SetGoalViewModel: ObservableObject {
    let from: BusStop
    
    func setRoute(to: String, userModel: UserService) {
        userModel.addRoute(from: from.name, to: to)
    }
}

// View層でバリデーション
if viewModel.from.name == selectedGoal { showAlert.toggle() }
if userModel.isRouteSaved(...) { showAlert.toggle() }
```

**変更後**:
```swift
@MainActor
@Observable
final class SetGoalViewModel {
    struct State {
        var selectedGoal: String = "南草津駅"
        var showAlert: Bool = false
        var alertMessage: String = ""
    }
    var state = State()
    
    @discardableResult
    func setRoute(to: String, userModel: UserService) -> Bool {
        // バリデーション: 乗り場と降り場が同じ
        if from.name == to {
            state.alertMessage = "乗り場と降り場が同じようです"
            state.showAlert = true
            return false
        }
        // バリデーション: 既に登録済み
        if userModel.isRouteSaved(from: from.name, to: to) {
            state.alertMessage = "既に登録済みのルートです"
            state.showAlert = true
            return false
        }
        userModel.addRoute(from: from.name, to: to)
        return true
    }
}
```

### 3. AddLineView の更新 ✅

**変更内容**:
- `@StateObject` → `@State` に変更（iOS 17+ の推奨パターン）
- 全てのバインディングを `viewModel.state.*` 経由に統一

**変更前**:
```swift
@StateObject var viewModel = AddLineViewModel()

.searchable(text: $viewModel.searchQuery)
.onChange(of: viewModel.searchQuery) {
    viewModel.filterBusStops(with: viewModel.searchQuery)
}
ForEach(viewModel.filteredData, id: \.self) { ... }
```

**変更後**:
```swift
@State private var viewModel = AddLineViewModel()

.searchable(text: $viewModel.state.searchQuery)
.onChange(of: viewModel.state.searchQuery) {
    viewModel.filterBusStops(with: viewModel.state.searchQuery)
}
ForEach(viewModel.state.filteredData, id: \.self) { ... }
```

### 4. SetGoalView の更新 ✅

**変更内容**:
- `@StateObject` → `@State` に変更
- バリデーションロジックをViewModel委譲
- アラート表示をViewModel管理に統一
- タイポ修正: `selectStaition` → `selectStation`

**変更前**:
```swift
@StateObject private var viewModel: SetGoalViewModel
@State private var selectedGoal = "南草津駅"
@State private var showAlert = false

// View内でバリデーション
Button {
    if viewModel.from.name == selectedGoal {
        showAlert.toggle()
        return
    } else if userModel.isRouteSaved(from: viewModel.from.name, to: selectedGoal) {
        showAlert.toggle()
        return
    }
    viewModel.setRoute(to: selectedGoal, userModel: userModel)
    path.removeLast(path.count)
}

.alert(isPresented: $showAlert) {
    Alert(title: Text("設定エラー"),
          message: Text(viewModel.from.name == selectedGoal ? "乗り場と降り場が同じようです" : "既に登録済みのルートです"),
          dismissButton: .default(Text("OK"))
    )
}
```

**変更後**:
```swift
@State private var viewModel: SetGoalViewModel
@State private var selectStation = true

// ViewModelでバリデーション
Button {
    if viewModel.setRoute(to: viewModel.state.selectedGoal, userModel: userModel) {
        path.removeLast(path.count)
    }
}

.alert(isPresented: $viewModel.state.showAlert) {
    Alert(
        title: Text("設定エラー"),
        message: Text(viewModel.state.alertMessage),
        dismissButton: .default(Text("OK")) {
            viewModel.dismissAlert()
        }
    )
}
```

## 📊 効果

### アーキテクチャ改善
- ✅ **状態管理パターン統一**: HomeViewModel と同じ `State` 構造体パターン
- ✅ **責務の明確化**: バリデーションロジックがView層からViewModel層へ
- ✅ **iOS 17+ 準拠**: 最新の @Observable パターン採用
- ✅ **依存削減**: Combine framework 不要

### コード品質
- ✅ **可読性向上**: State構造体で状態が一目瞭然
- ✅ **保守性向上**: ロジックがViewModel集約
- ✅ **型安全性向上**: エラーメッセージが型で管理

### パフォーマンス
- ✅ **不要な再描画削減**: @Observable の細かい変更検知
- ✅ **軽量化**: Combine framework 依存削除

### ファイル変更統計
```
4 files changed, 124 insertions(+), 45 deletions(-)

AddLineViewModel.swift:   37 → 61行 (+24行: State構造体・エラー処理)
SetGoalViewModel.swift:   16 → 70行 (+54行: State構造体・バリデーション)
AddLineView.swift:        33 → 33行 (±0行: State経由バインディング)
SetGoalView.swift:        79 → 78行 (-1行: ロジック集約で簡素化)
```

## ✅ 完了条件チェック

- [x] AddLineViewModel が @Observable で実装済み
- [x] SetGoalViewModel が @Observable で実装済み
- [x] AddLineView で @State バインディング対応済み
- [x] SetGoalView で @State バインディング対応済み
- [x] @StateObject/@ObservableObject が廃止済み
- [x] 状態管理パターンが統一済み（HomeViewModel パターン準拠）
- [x] バリデーションロジックがViewModel集約済み

## 🔗 関連Issue

- Closes #25 (Phase 2-1: 既存ViewModelの@Observable化)
- Parent: #22 (Epic: アーキテクチャ移行)
- Depends on: #24 (Repository確立) ✅ 完了済み
- Next: #26 (Phase 2-2: 状態管理パターンの統一)

## 📝 レビューポイント

1. **State構造体設計**: 状態管理が適切に構造化されているか？
2. **バリデーション**: SetGoalViewModelのバリデーションロジックはViewModel層で適切か？
3. **エラー処理**: AddLineViewModelのエラーメッセージ追加は必要十分か？
4. **バインディング**: @State経由の状態変更は期待通りに動作するか？
5. **iOS版対応**: @ObservableはiOS 17+が必要だが、デプロイメントターゲットは適切か？

## 🧪 テスト方針

- [ ] AddLineView でバス停検索が正常に動作するか確認
- [ ] SetGoalView で目的地選択・路線追加が正常に動作するか確認
- [ ] バリデーション（同じバス停・重複路線）が正常に動作するか確認
- [ ] アラート表示が正常に動作するか確認
- [ ] ナビゲーションリセットが正常に動作するか確認

## 🎓 学習ポイント

### @Observable vs ObservableObject

| 項目 | ObservableObject | @Observable |
|------|-----------------|-------------|
| **導入** | iOS 13+ | iOS 17+ |
| **依存** | Combine framework | Observation framework |
| **View側** | @StateObject, @ObservedObject | @State, @Bindable |
| **パフォーマンス** | プロパティ全体を監視 | 使用プロパティのみ監視 |
| **ボイラープレート** | @Published 必要 | 不要（自動推論） |

### State構造体パターンの利点

1. **可読性**: 状態が1箇所に集約され、一目で把握可能
2. **保守性**: 新しい状態追加が容易
3. **テスタビリティ**: State構造体単位でテスト可能
4. **スナップショット**: 状態の保存・復元が容易

## 📚 次のステップ

Phase 2-2（状態管理パターンの統一）に進む準備が整いました：
- UserService の @Observable 化
- TimeTableViewModel の @Observable 化（存在する場合）
- その他のObservableObjectパターンの統一