### PR TITLE
📝 Docs: Add comprehensive documentation to SetGoalViewModel

### DIFF
--- a/BusdesNativeiOS/ViewModels/SetGoalViewModel.swift
+++ b/BusdesNativeiOS/ViewModels/SetGoalViewModel.swift
@@ -3,7 +3,38 @@ import SwiftData
 import Observation
 
 /// 目的地設定画面のViewModel
-/// @Observableパターンで状態管理を簡素化
+///
+/// ## 概要
+/// 新しいバス路線を追加する際の目的地選択と路線登録を管理します。
+/// `@Observable`マクロによる状態管理とSwiftDataとの統合により、
+/// シンプルかつ型安全なデータ永続化を実現しています。
+///
+/// ## 主な機能
+/// - 目的地の選択（南草津駅 or 立命館大学）
+/// - 路線の登録（重複・無効チェック付き）
+/// - バリデーションエラーのアラート表示
+/// - ローディング状態の管理
+///
+/// ## 使用例
+/// ```swift
+/// let busStop = BusStop(name: "立命館大学", kana: "りつめいかんだいがく")
+/// let viewModel = SetGoalViewModel(from: busStop)
+///
+/// // 目的地を選択
+/// viewModel.selectGoal("南草津駅")
+///
+/// // 路線を登録
+/// let success = viewModel.setRoute(
+///     to: viewModel.state.selectedGoal,
+///     modelContext: modelContext,
+///     existingRoutes: routes
+/// )
+/// ```
+///
+/// ## SwiftDataとの統合
+/// `setRoute(to:modelContext:existingRoutes:)`メソッドでSwiftDataに直接アクセスし、
+/// `Route`エンティティの作成・保存を行います。これにより、Repositoryパターンを
+/// 介さずにシンプルな実装を実現しています。
 @MainActor
 @Observable
 final class SetGoalViewModel {
@@ -11,6 +42,12 @@ final class SetGoalViewModel {
     // MARK: - State
 
     /// 画面の状態を1つの構造体で管理
+    ///
+    /// ## プロパティ
+    /// - `selectedGoal`: 現在選択されている目的地（デフォルト: "南草津駅"）
+    /// - `showAlert`: アラート表示フラグ
+    /// - `alertMessage`: アラートに表示するメッセージ
+    /// - `loadingState`: 路線登録処理中のローディング状態
     struct State {
         var selectedGoal: String = "南草津駅"
         var showAlert: Bool = false
@@ -22,10 +59,14 @@ final class SetGoalViewModel {
 
     // MARK: - Properties
 
+    /// 出発地バス停
+    /// 路線登録時に`from`として使用されます
     let from: BusStop
 
     // MARK: - Initialization
 
+    /// イニシャライザ
+    /// - Parameter from: 出発地バス停（立命館大学 or 南草津駅）
     init(from: BusStop) {
         self.from = from
     }
@@ -33,17 +74,56 @@ final class SetGoalViewModel {
     // MARK: - Public Methods
 
     /// 目的地を選択
+    ///
+    /// ユーザーがPickerで目的地を変更した際に呼び出されます。
+    /// 状態を更新するだけで、バリデーションは行いません。
+    ///
     /// - Parameter destination: 目的地名（"南草津駅" or "立命館大学"）
+    ///
+    /// ## 使用例
+    /// ```swift
+    /// viewModel.selectGoal("南草津駅")
+    /// print(viewModel.state.selectedGoal) // "南草津駅"
+    /// ```
     func selectGoal(_ destination: String) {
         state.selectedGoal = destination
     }
 
     /// 路線を設定（SwiftData直接操作）
+    ///
+    /// 新しいバス路線をSwiftDataに保存します。
+    /// 保存前に以下のバリデーションを実行します：
+    /// 1. 出発地と目的地が同じでないか
+    /// 2. 同じ路線が既に登録されていないか
+    ///
+    /// バリデーションエラー時は`state.showAlert`がtrueになり、
+    /// エラーメッセージが`state.alertMessage`に設定されます。
+    ///
     /// - Parameters:
-    ///   - to: 目的地
-    ///   - modelContext: SwiftDataのModelContext
+    ///   - to: 目的地名
+    ///   - modelContext: SwiftDataのModelContext（保存先）
     ///   - existingRoutes: 既存の路線リスト（重複チェック用）
+    ///
     /// - Returns: 設定が成功したかどうか
+    ///   - `true`: 路線が正常に保存された
+    ///   - `false`: バリデーションエラーまたは保存失敗
+    ///
+    /// ## エラーケース
+    /// - **出発地と目的地が同じ**: `state.alertMessage = "乗り場と降り場が同じようです"`
+    /// - **既に登録済み**: `state.alertMessage = "既に登録済みのルートです"`
+    /// - **保存失敗**: `state.alertMessage = "路線の追加に失敗しました: <エラー詳細>"`
+    ///
+    /// ## 使用例
+    /// ```swift
+    /// let success = viewModel.setRoute(
+    ///     to: "南草津駅",
+    ///     modelContext: modelContext,
+    ///     existingRoutes: currentRoutes
+    /// )
+    /// if success {
+    ///     // 画面を閉じる、または成功メッセージを表示
+    /// }
+    /// ```
     @discardableResult
     func setRoute(to: String, modelContext: ModelContext, existingRoutes: [Route]) -> Bool {
         state.loadingState.startLoading()
@@ -81,6 +161,13 @@ final class SetGoalViewModel {
     }
 
     /// アラートを閉じる
+    ///
+    /// エラーアラートの表示をリセットします。
+    /// アラートのOKボタンが押された際に呼び出されます。
+    ///
+    /// ## 動作
+    /// - `state.showAlert`を`false`に設定
+    /// - `state.alertMessage`を空文字列にクリア
     func dismissAlert() {
         state.showAlert = false
         state.alertMessage = ""


### PR DESCRIPTION
## 概要
SetGoalViewModelに包括的なSwiftDocコメントを追加しました。

## 変更内容

### クラスレベルのドキュメント
- **概要セクション**: ViewModelの役割と責務を説明
- **主な機能リスト**: 提供する機能を箇条書きで明示
- **使用例**: 実際のコード例を含めた使い方ガイド
- **SwiftDataとの統合**: データ永続化の実装方法を説明

### Stateドキュメント
- 各プロパティの詳細な説明
- デフォルト値の明示
- プロパティの用途を明確化

### メソッドドキュメント

#### selectGoal(_:)
- メソッドの目的と動作を説明
- パラメータの詳細
- 使用例を追加

#### setRoute(to:modelContext:existingRoutes:)
- 詳細なバリデーションロジックの説明
- すべてのエラーケースをドキュメント化
- パラメータと戻り値の詳細な説明
- 実用的なコード例

#### dismissAlert()
- メソッドの動作を明確化
- 具体的な処理内容を説明

## ドキュメントの質
- すべての公開APIに詳細なコメント
- コード例を含む実践的なドキュメント
- Markdownフォーマットで読みやすく整形
- Swiftの標準ドキュメント規約に準拠

## 開発者への恩恵
- コードの理解が容易に
- 使い方がすぐにわかる実用的な例
- バリデーションロジックの明確化
- メンテナンス性の向上

🤖 Generated with [Claude Code](https://claude.com/claude-code)